### PR TITLE
KERNELBOOST: 57 cycles gained on HSync entry, giving ~2000 extra VBla…

### DIFF
--- a/kernel/uzeboxCore.c
+++ b/kernel/uzeboxCore.c
@@ -160,7 +160,12 @@ const u16 io_table[] PROGMEM ={
 	io_set(TCCR2B,(1<<CS20)),  //enable timer, no pre-scaler	
 	io_set(SYNC_PORT,(1<<SYNC_PIN)|(1<<VIDEOCE_PIN)), //set sync & chip enable line to hi
 	
-	io_set(OCR1BL,0x4f),		//lo8(0x36e-31) eq pulse pulse restore
+	// *** Kernel boost hack ***
+	//
+	// Shift COMPB down by 51 cycles to align its head cycle count with
+	// the HSync entry's cycle count
+	//
+	io_set(OCR1BL,0x4f - 51),		//lo8(0x36e-31) eq pulse pulse restore
 	io_set(OCR1BH,0x03)			//hi8(0x36e-31)	
 };
 


### PR DESCRIPTION
…nk cycles

The modification replaces the jitter elimination part in the HSync and
VSync entry codes to a more efficient solution.

It is not fully compatible with the original kernel, but mostly works.
Notably all timing is shifted 57 cycles "down" relative to the timer,
which normally isn't a problem (expect for timer value related comments).
However video modes using the timer for terminating their scanlines (such
as Mode 13) doesn't work with this modification! (their timer related
logic has to be modified to follow the 57 cycles shift)